### PR TITLE
Fix isort

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,9 +22,9 @@ go_register_toolchains()
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "64104b8d7b623e804f981b52378267148cca42af4b77fe70ddfc27857dc5bae0",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+    sha256 = "b0a1da830747a2ffc1125fc84dbd3fe32a876396592d4580501749a2d0d0cb15",
+    strip_prefix = "protobuf-3.12.2",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.2.zip"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -33,9 +33,9 @@ protobuf_deps()
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    sha256 = "deadb35ae3877aa118ba20531afb2e2e4e8aaac5d3df5d5b51cbb3f0f2e0581e",
-    strip_prefix = "buildtools-master",
-    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
+    sha256 = "55095ba38ab866166052d7e99a5ff237797cf86de4481f07d7f43540e79641df",
+    strip_prefix = "buildtools-3.2.0",
+    url = "https://github.com/bazelbuild/buildtools/archive/3.2.0.zip",
 )
 
 load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")

--- a/python/pylint/rules.bzl
+++ b/python/pylint/rules.bzl
@@ -46,8 +46,10 @@ def pylint_test(
     )
 
     args = list(args) + ["--score", "no"]
+    pylint_data = list()
 
     if rcfile != None:
+        pylint_data.append(rcfile)
         args.extend(["--rcfile", "$(location %s)" % rcfile])
 
     for src in srcs:
@@ -55,11 +57,16 @@ def pylint_test(
 
     py_test(
         name = name,
-        srcs = [entry_point_output] + srcs,
-        data = [rcfile] + data,
+        srcs = [entry_point_output] + list(srcs),
+        data = pylint_data + data,
         main = entry_point_output,
         deps = depset(
-            direct = ["@pip3//pylint"],
+            direct = [
+                "@pip3//pylint",
+                # we need an explicit dep on toml because rules_pip doesn't support
+                # adding a dep on `isort[pyproject]`.
+                "@pip3//toml",
+            ],
             transitive = [depset(deps)],
         ),
         python_version = "PY3",

--- a/python/pytest/rules.bzl
+++ b/python/pytest/rules.bzl
@@ -59,16 +59,12 @@ def pytest_test(
 
         if version == "PY3":
             version_args.extend([
-                "--isort",
                 "--cov",
                 "--no-cov-on-fail",
             ])
 
-            # isort implicitly requires toml to use `pyproject.toml:[tool.isort]`
             pytest_deps.extend([
-                "@pip3//pytest_isort",
                 "@pip3//pytest_timeout",
-                "@pip3//toml",
                 "@pip3//pytest_cov",
                 "@pip3//pdbpp",
             ])

--- a/thirdparty/pip/3/requirements-linux.txt
+++ b/thirdparty/pip/3/requirements-linux.txt
@@ -57,7 +57,7 @@ importlib-metadata==1.4.0 \
 isort==4.3.21 \
     --hash=sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1 \
     --hash=sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd \
-    # via pylint, pytest-isort
+    # via pylint
 lazy-object-proxy==1.4.3 \
     --hash=sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d \
     --hash=sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449 \
@@ -117,9 +117,6 @@ pyparsing==2.4.6 \
 pytest-cov==2.8.1 \
     --hash=sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b \
     --hash=sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626
-pytest-isort==0.3.1 \
-    --hash=sha256:3be60e0de277b420ff89303ca6494320c41f7819ffa898756b90ef976e4c636a \
-    --hash=sha256:4bfee60dad1870b51700d55a85f5ceda766bd9d3d2878c1bbabee80e61b1be1a
 pytest-randomly==3.1.0 \
     --hash=sha256:5facc2b5ac56e36b9c4bf14f49cc7b4c95427835bbf4a3c739b71a5f5f82d58a \
     --hash=sha256:9256c9ff88466f7bf9794d2eeeea8fbf1cd1bc8df1b3575df59e89b8813bffaa
@@ -133,9 +130,9 @@ six==1.14.0 \
     --hash=sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a \
     --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c \
     # via astroid, packaging
-toml==0.10.0 \
-    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
-    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e
+toml==0.10.1 \
+    --hash=sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f \
+    --hash=sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88
 typed-ast==1.4.1 \
     --hash=sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355 \
     --hash=sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919 \

--- a/thirdparty/pip/3/requirements-osx.txt
+++ b/thirdparty/pip/3/requirements-osx.txt
@@ -57,7 +57,7 @@ importlib-metadata==1.4.0 \
 isort==4.3.21 \
     --hash=sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1 \
     --hash=sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd \
-    # via pylint, pytest-isort
+    # via pylint
 lazy-object-proxy==1.4.3 \
     --hash=sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d \
     --hash=sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449 \
@@ -117,9 +117,6 @@ pyparsing==2.4.6 \
 pytest-cov==2.8.1 \
     --hash=sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b \
     --hash=sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626
-pytest-isort==0.3.1 \
-    --hash=sha256:3be60e0de277b420ff89303ca6494320c41f7819ffa898756b90ef976e4c636a \
-    --hash=sha256:4bfee60dad1870b51700d55a85f5ceda766bd9d3d2878c1bbabee80e61b1be1a
 pytest-randomly==3.1.0 \
     --hash=sha256:5facc2b5ac56e36b9c4bf14f49cc7b4c95427835bbf4a3c739b71a5f5f82d58a \
     --hash=sha256:9256c9ff88466f7bf9794d2eeeea8fbf1cd1bc8df1b3575df59e89b8813bffaa
@@ -133,9 +130,9 @@ six==1.14.0 \
     --hash=sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a \
     --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c \
     # via astroid, packaging
-toml==0.10.0 \
-    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
-    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e
+toml==0.10.1 \
+    --hash=sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f \
+    --hash=sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88
 typed-ast==1.4.1 \
     --hash=sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355 \
     --hash=sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919 \

--- a/thirdparty/pip/3/requirements.in
+++ b/thirdparty/pip/3/requirements.in
@@ -4,7 +4,6 @@ pdbpp
 pylint
 pytest
 pytest-cov
-pytest-isort
 pytest-randomly
 pytest-timeout
 toml


### PR DESCRIPTION
Update how we run isort

Before:
 - `pytest_test` checked import order using `isort` (via `pytest-isort`)
 - `pylint_test` checked import order (and unknown to me,) used `isort`

Q: Why was this not an issue before?
A: `toml` was installed into the system python. This meant that the `isort` within `pylint` was happy.

Now:
 - `pylint_test` has an explicit dep on `isort[pyproject]` so that `isort` can pick up its config from a `pyproject.toml` file that is specified in the `data` section.
 - `pytest_test` no longer checks import order as this is redundant.