### PR TITLE
Use 128technology rules_pip fork

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -69,14 +69,11 @@ def rules_128tech_deps():
 
     maybe(
         http_archive,
-        name = "com_apt_itude_rules_pip",
-        sha256 = "d63149e2f327c1411e1853bbc3379d978945d159da0602abc67e02373ee9206c",
-        strip_prefix = "rules_pip-aafdefd2bf1a9f6995669c1d744da493de9a7b75",
+        name = "com_128technology_rules_pip",
+        sha256 = "9642882586da0f504ab2c13f5d4421bd8d5b9c84d0822d51b7031f483c502f88",
+        strip_prefix = "rules_pip-fe10a421b30dfd6a4aa8dc750f0e9f34edf5dc0b",
         type = "tar.gz",
-        url = "https://github.com/apt-itude/rules_pip/archive/aafdefd2bf1a9f6995669c1d744da493de9a7b75.tar.gz",
-        patches = [Label("//thirdparty/pip:reproducible_wheel.patch")],
-        patch_args = ["-p1"],
-        patch_tool = "patch",
+        url = "https://github.com/128technology/rules_pip/archive/fe10a421b30dfd6a4aa8dc750f0e9f34edf5dc0b.tar.gz",
     )
 
     maybe(

--- a/thirdparty/pip/2/BUILD.bazel
+++ b/thirdparty/pip/2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@com_apt_itude_rules_pip//rules:compile.bzl", "compile_pip_requirements")
+load("@com_128technology_rules_pip//rules:compile.bzl", "compile_pip_requirements")
 load("//python:versions.bzl", "PYTHON2")
 
 compile_pip_requirements(
@@ -6,8 +6,8 @@ compile_pip_requirements(
     python_interpreter = PYTHON2,
     requirements_in = ":requirements.in",
     requirements_txt = select({
-        "@com_apt_itude_rules_pip//:linux": "requirements-linux.txt",
-        "@com_apt_itude_rules_pip//:osx": "requirements-osx.txt",
+        "@com_128technology_rules_pip//:linux": "requirements-linux.txt",
+        "@com_128technology_rules_pip//:osx": "requirements-osx.txt",
     }),
 )
 

--- a/thirdparty/pip/3/BUILD.bazel
+++ b/thirdparty/pip/3/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@com_apt_itude_rules_pip//rules:compile.bzl", "compile_pip_requirements")
+load("@com_128technology_rules_pip//rules:compile.bzl", "compile_pip_requirements")
 load("//python:versions.bzl", "PYTHON3")
 
 compile_pip_requirements(
@@ -6,8 +6,8 @@ compile_pip_requirements(
     python_interpreter = PYTHON3,
     requirements_in = ":requirements.in",
     requirements_txt = select({
-        "@com_apt_itude_rules_pip//:linux": "requirements-linux.txt",
-        "@com_apt_itude_rules_pip//:osx": "requirements-osx.txt",
+        "@com_128technology_rules_pip//:linux": "requirements-linux.txt",
+        "@com_128technology_rules_pip//:osx": "requirements-osx.txt",
     }),
 )
 

--- a/thirdparty/pip/README.md
+++ b/thirdparty/pip/README.md
@@ -165,7 +165,7 @@ Bazel unfortunately swallows output from the tools that it executes when fetchin
 In order to debug the tool that is used for fetching the pip dependencies, execute the following commands:
 
 ```
-python<major>.<minor> $(bazel info output_base)/external/com_apt_itude_rules_pip/tools/create_pip_repository.par /tmp/bazel-pip-repo thirdparty/pip/<major>/requirements-<platform>.txt
+python<major>.<minor> $(bazel info output_base)/external/com_128technology_rules_pip/tools/create_pip_repository.par /tmp/bazel-pip-repo thirdparty/pip/<major>/requirements-<platform>.txt
 ```
 
 Where:

--- a/thirdparty/pip/README.md
+++ b/thirdparty/pip/README.md
@@ -78,14 +78,14 @@ letters lowercased and all hyphens replaced with underscores
 
 `pip/3/requirements.in`:
 
-```
+```txt
 python-dateutil
 PyYAML
 ```
 
 `BUILD.bazel`:
 
-```
+```py
 py_library(
     name = "mylib",
     srcs = "mylib.py",
@@ -104,7 +104,7 @@ Bazel provides little to no information while resolving/retrieving external depe
 
 For example, Bazel commonly prints error messages like the following:
 
-```
+```txt
 ERROR: Analysis of target '//packaging/apps/blaster/saltlib/saltlib:arrow' failed; build aborted: no such package '@pip2//pyyaml': BUILD file not found on package path
 INFO: Elapsed time: 18.842s
 INFO: 0 processes.
@@ -112,7 +112,7 @@ FAILED: Build did NOT complete successfully (74 packages loaded, 717 targets con
     currently loading: @pip2//pytest_mock ... (4 packages)
 ```
 
-This error does not occur until _after_ externel dependencies have been fetched and Bazel has proceeded to analyze the dependency tree. The only thing it indicates is that the `@pip2//pyyaml` package was not properly fetched, but it does not provide any useful context.
+This error does not occur until _after_ external dependencies have been fetched and Bazel has proceeded to analyze the dependency tree. The only thing it indicates is that the `@pip2//pyyaml` package was not properly fetched, but it does not provide any useful context.
 
 Try the following steps in order to resolve the issue:
 
@@ -120,7 +120,7 @@ Try the following steps in order to resolve the issue:
 
 Running this command before any build or test commands will remove all of the fetched external dependencies and force Bazel to start from scratch:
 
-```
+```sh
 bazel clean --expunge
 ```
 
@@ -128,7 +128,7 @@ bazel clean --expunge
 
 Bazel stores the fetched pip dependencies in the following directory:
 
-```
+```sh
 $(bazel info output_base)/external/pip<major>/
 ```
 
@@ -140,13 +140,13 @@ If the directory does not contain any wheel files, this can be an indication tha
 
 If the directory contains wheel files, there was most likely an error running the `create_pip_repository` tool. See `Try manually creating the pip repository to check for errors` below.
 
-For more information about the output directories created by Bazel, see https://docs.bazel.build/versions/master/output_directories.html.
+For more information about the output directories created by Bazel, see [the official documentation](https://docs.bazel.build/versions/master/output_directories.html).
 
 #### Make sure the required Python interpreters are available
 
 The correct Python interpreters for each major version must be available within the Bazel execution environment. To verify this, execute the following:
 
-```
+```sh
 cd $(bazel info output_base)
 python2.<minor> --version
 python3.<minor> --version
@@ -164,7 +164,7 @@ Bazel unfortunately swallows output from the tools that it executes when fetchin
 
 In order to debug the tool that is used for fetching the pip dependencies, execute the following commands:
 
-```
+```sh
 python<major>.<minor> $(bazel info output_base)/external/com_128technology_rules_pip/tools/create_pip_repository.par /tmp/bazel-pip-repo thirdparty/pip/<major>/requirements-<platform>.txt
 ```
 

--- a/thirdparty/pip/repositories.bzl
+++ b/thirdparty/pip/repositories.bzl
@@ -3,7 +3,7 @@ Thirdparty pip dependencies
 """
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@com_apt_itude_rules_pip//rules:repository.bzl", "pip_repository")
+load("@com_128technology_rules_pip//rules:repository.bzl", "pip_repository")
 load("//python:versions.bzl", "PYTHON2", "PYTHON3")
 load("//python:pip.bzl", "pip_aliases")
 


### PR DESCRIPTION
Closes #11 

* Drop reproducible wheel patch since it is upstreamed in the 128T fork
* Rename everything to `com_128technology_rules_pip`
* Update README with minor markdown changes