### PR TITLE
Create pylint plugin for autospec=True on mock.patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+line-length = 88
+include = '\.py$'
+
+[tool.isort]
+# See https://github.com/timothycrosley/isort/issues/694
+# on how this configuration is valid with black.
+line_length=88
+multi_line_output=3
+lines_after_imports=2
+include_trailing_comma=true
+combine_as_imports=true
+
+default_section="THIRDPARTY"
+
+# necessary when experiencing incorrect "wrong-import-order" linting errors
+known_first_party = [
+    "rules_128tech"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,5 @@
-[tool.black]
-line-length = 88
-include = '\.py$'
-
 [tool.isort]
-# See https://github.com/timothycrosley/isort/issues/694
-# on how this configuration is valid with black.
-line_length=88
-multi_line_output=3
-lines_after_imports=2
-include_trailing_comma=true
-combine_as_imports=true
-
-default_section="THIRDPARTY"
-
-# necessary when experiencing incorrect "wrong-import-order" linting errors
+profile = "black"
 known_first_party = [
-    "rules_128tech"
+  "rules_128tech",
 ]

--- a/python/lint/rules.bzl
+++ b/python/lint/rules.bzl
@@ -10,7 +10,7 @@ _AUTO_ADD_RULE_TYPES = [
     "py_test",
 ]
 
-def add_python_lint_tests(pylint = True, rcfile = None, **kwargs):
+def add_python_lint_tests(pylint = True, rcfile = None, deps = [], **kwargs):
     """
     Add all the available static analysis available for each python target in the current BUILD file.
 
@@ -27,6 +27,7 @@ def add_python_lint_tests(pylint = True, rcfile = None, **kwargs):
     Args:
         pylint(bool): control whether pylint tests are created.
         rcfile(label): pylint configuration file
+        deps(label_list): extra dependencies of the pylint test
         **kwargs: Pass other keyword arguments directly to pylint_test.
 
     """
@@ -49,7 +50,7 @@ def add_python_lint_tests(pylint = True, rcfile = None, **kwargs):
         pylint_test(
             name = "pylint",
             srcs = depset(pylint_srcs).to_list(),
-            deps = depset(transitive = [depset(pylint_deps)]),
+            deps = depset(direct = deps, transitive = [depset(pylint_deps)]),
             rcfile = rcfile,
             **kwargs
         )

--- a/python/pylint/rules.bzl
+++ b/python/pylint/rules.bzl
@@ -37,7 +37,12 @@ def pylint_test(
         **kwargs(dict): arguments to pass to the native py_test rule
     """
 
-    args = list(args) + ["--score", "no"]
+    args = list(args) + [
+        "--score",
+        "no",
+        "--load-plugins",
+        "mock_patch_autospec",
+    ]
     pylint_data = list()
 
     if rcfile != None:
@@ -55,11 +60,12 @@ def pylint_test(
         main = main,
         deps = depset(
             direct = [
-                "@rules_128tech//rules_128tech:sharder",
                 "@pip3//pylint",
                 # we need an explicit dep on toml because rules_pip doesn't support
                 # adding a dep on `isort[pyproject]`.
                 "@pip3//toml",
+                "@rules_128tech//rules_128tech:sharder",
+                "@rules_128tech//rules_128tech/pylint_plugins:mock_patch_autospec",
             ],
             transitive = [depset(deps)],
         ),

--- a/python/pylint/rules.bzl
+++ b/python/pylint/rules.bzl
@@ -41,7 +41,7 @@ def pylint_test(
         "--score",
         "no",
         "--load-plugins",
-        "mock_patch_autospec",
+        "rules_128tech.pylint_plugins.mock_patch_autospec",
     ]
     pylint_data = list()
 

--- a/rules_128tech/pylint_plugins/BUILD.bazel
+++ b/rules_128tech/pylint_plugins/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_128tech//python/pytest:rules.bzl", "pytest_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,4 +15,11 @@ py_library(
         "@pip3//astroid",
         "@pip3//pylint",
     ],
+)
+
+pytest_test(
+    name = "mock_patch_autospec_test",
+    srcs = [":mock_patch_autospec_test.py"],
+    python_version = "PY3",
+    deps = [":mock_patch_autospec"],
 )

--- a/rules_128tech/pylint_plugins/BUILD.bazel
+++ b/rules_128tech/pylint_plugins/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "mock_patch_autospec",
+    testonly = True,
+    srcs = [
+        ":__init__.py",
+        ":mock_patch_autospec.py",
+    ],
+    imports = ["."],
+    srcs_version = "PY3",
+    deps = [
+        "@pip3//astroid",
+        "@pip3//pylint",
+    ],
+)

--- a/rules_128tech/pylint_plugins/BUILD.bazel
+++ b/rules_128tech/pylint_plugins/BUILD.bazel
@@ -9,7 +9,6 @@ py_library(
         ":__init__.py",
         ":mock_patch_autospec.py",
     ],
-    imports = ["."],
     srcs_version = "PY3",
     deps = [
         "@pip3//astroid",

--- a/rules_128tech/pylint_plugins/mock_patch_autospec.py
+++ b/rules_128tech/pylint_plugins/mock_patch_autospec.py
@@ -24,7 +24,7 @@ class MockPatchAutospecChecker(BaseChecker):
     priority = -1
     msgs = {
         "W1280": (
-            "Using %s without explicitly setting `autospec` is not recommended.",
+            "Using `%s` without explicitly setting `autospec` is not recommended.",
             name,
             (
                 "All mock patches should use autospec=True to avoid allowing calls "

--- a/rules_128tech/pylint_plugins/mock_patch_autospec.py
+++ b/rules_128tech/pylint_plugins/mock_patch_autospec.py
@@ -5,9 +5,6 @@ setting autospec=True.
 Based on http://pylint.pycqa.org/en/latest/how_tos/custom_checkers.html#write-a-checker
 """
 
-# Required because this is a dynamically loaded plugin:
-# pylint:disable=no-name-in-module,import-error
-
 import astroid
 import astroid.node_classes
 from pylint.checkers import BaseChecker
@@ -46,8 +43,7 @@ class MockPatchAutospecChecker(BaseChecker):
             return
 
         if not isinstance(call.func.expr, astroid.node_classes.Name):
-            # A method call on a complex expression, literal, or something,
-            # too complex to deal with
+            # A method call on a complex expression, literal, or something
             return
 
         if call.func.expr.name not in ("mock", "mocker"):

--- a/rules_128tech/pylint_plugins/mock_patch_autospec.py
+++ b/rules_128tech/pylint_plugins/mock_patch_autospec.py
@@ -1,0 +1,73 @@
+"""
+A plugin to detect and disallow the use of mock.patch or mocker.patch without
+setting autospec=True.
+
+Based on http://pylint.pycqa.org/en/latest/how_tos/custom_checkers.html#write-a-checker
+"""
+
+# Required because this is a dynamically loaded plugin:
+# pylint:disable=no-name-in-module,import-error
+
+import astroid
+import astroid.node_classes
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+
+
+def register(linter):
+    linter.register_checker(MockPatchAutospecChecker(linter))
+
+
+class MockPatchAutospecChecker(BaseChecker):
+    """A pylint checker to detect use of mock.patch without autospec=True"""
+
+    __implements__ = IAstroidChecker
+
+    name = "mock-patch-autospec"
+    priority = -1
+    msgs = {
+        "W1280": (
+            "Uses mock.patch without autospec=True.",
+            name,
+            (
+                "All mock patches should use autospec=True to avoid allowing calls "
+                "to functions that don't exist in production code"
+            ),
+        ),
+    }
+
+    def visit_call(self, call: astroid.node_classes.Call) -> None:
+        if not isinstance(call.func, astroid.node_classes.Attribute):
+            # Not a method call, not applicable
+            return
+
+        if call.func.attrname != "patch":
+            # Some other method, not applicable
+            return
+
+        if not isinstance(call.func.expr, astroid.node_classes.Name):
+            # A method call on a complex expression, literal, or something,
+            # too complex to deal with
+            return
+
+        if call.func.expr.name not in ("mock", "mocker"):
+            # Call to .patch() on some other object, I guess...
+            return
+
+        if call.keywords:
+            for keyword in call.keywords:
+                if keyword.arg == "autospec":
+                    if (
+                        isinstance(keyword.value, astroid.node_classes.Const)
+                        and keyword.value.value is True
+                    ):
+                        # They did the right thing!
+                        return
+
+                    # They passed a non-True value, probably an error
+                    self.add_message(
+                        "mock-patch-autospec", node=keyword.value,
+                    )
+
+        # We looked at all the kwargs and didn't find autospec=True, uh-oh
+        self.add_message("mock-patch-autospec", node=call)

--- a/rules_128tech/pylint_plugins/mock_patch_autospec.py
+++ b/rules_128tech/pylint_plugins/mock_patch_autospec.py
@@ -40,32 +40,61 @@ class MockPatchAutospecChecker(BaseChecker):
             # Not a method call, not applicable
             return
 
-        if call.func.attrname != "patch":
-            # Some other method, not applicable
+        if call.func.attrname == "dict":
+            # patch.dict() does not accept spec-related parameters
             return
 
-        if not isinstance(call.func.expr, astroid.node_classes.Name):
-            # A method call on a complex expression, literal, or something
+        found_patch = False
+        expr = call.func
+        # Traverse the attribute looking for `patch`. This allows us to include
+        # mock.patch(), mock.patch.object(), mock.patch.multiple(), etc.
+        while isinstance(expr, astroid.node_classes.Attribute):
+            if expr.attrname == "patch":
+                found_patch = True
+
+            expr = expr.expr
+
+        if not found_patch or not isinstance(expr, astroid.node_classes.Name):
             return
 
-        if call.func.expr.name not in ("mock", "mocker"):
-            # Call to .patch() on some other object, I guess...
+        _parent_node, lookups = expr.lookup(expr.name)
+        for lookup in lookups:
+            if (
+                isinstance(lookup, astroid.node_classes.ImportFrom)
+                and lookup.modname == "unittest"
+            ):
+                self._check_patch_call(call)
+                return
+
+            if isinstance(lookup, astroid.node_classes.Import) and any(
+                orig_name == "unittest.mock" for orig_name, _alias in lookup.names
+            ):
+                self._check_patch_call(call)
+                return
+
+            # Pytest-mock fixtures are named "mocker" or "<scope>_mocker"
+            if isinstance(
+                lookup, astroid.node_classes.AssignName
+            ) and lookup.name.endswith("mocker"):
+                self._check_patch_call(call)
+                return
+
+    def _check_patch_call(self, call: astroid.node_classes.Call) -> None:
+        assert isinstance(call.func, astroid.node_classes.Attribute)
+
+        if call.func.attrname == "patch" and call.args and len(call.args) > 1:
+            # "new" is the second arg, and is incompatible with autospec
+            return
+        elif call.func.attrname == "object" and call.args and len(call.args) > 2:
+            # "new" is the third arg for patch.object()
             return
 
         if call.keywords:
             for keyword in call.keywords:
-                if keyword.arg == "autospec":
-                    if (
-                        isinstance(keyword.value, astroid.node_classes.Const)
-                        and keyword.value.value is True
-                    ):
-                        # They did the right thing!
-                        return
+                if keyword.arg in ("new", "spec", "spec_set", "autospec"):
+                    # All of these args are incompatible with one another, as
+                    # long as one of them specified we are good
+                    return
 
-                    # They passed a non-True value, probably an error
-                    self.add_message(
-                        "mock-patch-autospec", node=keyword.value,
-                    )
-
-        # We looked at all the kwargs and didn't find autospec=True, uh-oh
-        self.add_message("mock-patch-autospec", node=call)
+        # We looked at all the kwargs and didn't find 'autospec' or 'new', uh-oh
+        self.add_message(self.name, node=call, args=(call.func.as_string(),))

--- a/rules_128tech/pylint_plugins/mock_patch_autospec.py
+++ b/rules_128tech/pylint_plugins/mock_patch_autospec.py
@@ -20,15 +20,17 @@ class MockPatchAutospecChecker(BaseChecker):
 
     __implements__ = IAstroidChecker
 
-    name = "mock-patch-autospec"
+    name = "t128-mock-patch-autospec"
     priority = -1
     msgs = {
         "W1280": (
-            "Uses mock.patch without autospec=True.",
+            "Using %s without explicitly setting `autospec` is not recommended.",
             name,
             (
                 "All mock patches should use autospec=True to avoid allowing calls "
-                "to functions that don't exist in production code"
+                "to functions that don't exist in production code. See "
+                "https://docs.python.org/3.6/library/unittest.mock.html?#autospeccing "
+                "for more details"
             ),
         ),
     }

--- a/rules_128tech/pylint_plugins/mock_patch_autospec_test.py
+++ b/rules_128tech/pylint_plugins/mock_patch_autospec_test.py
@@ -1,7 +1,6 @@
 """Unit tests for the mock_patch_autospec plugin"""
 
 import contextlib
-from unittest import mock
 
 import astroid
 import astroid.node_classes
@@ -9,7 +8,6 @@ import pytest
 from pylint import testutils
 
 from rules_128tech.pylint_plugins import mock_patch_autospec
-
 
 _MOCK_PATCH_TEST_CASES = [
     pytest.param('("foo")', True, id="no_autospec",),
@@ -84,6 +82,11 @@ class TestUnittestMockPatch(testutils.CheckerTestCase):
             pytest.param(
                 "from unittest import mock", "mock.patch", id="partially_qualified"
             ),
+            pytest.param(
+                "from unittest import mock as aliased_mock",
+                "aliased_mock.patch",
+                id="partially_qualified_aliased",
+            ),
         ],
     )
     @pytest.mark.parametrize(
@@ -134,6 +137,14 @@ class TestUnittestMockPatch(testutils.CheckerTestCase):
                 "mock.patch.object",
                 id="partially_qualified",
             ),
+            pytest.param(
+                """
+                import time
+                from unittest import mock as aliased_mock
+                """,
+                "aliased_mock.patch.object",
+                id="partially_qualified_aliased",
+            ),
         ],
     )
     @pytest.mark.parametrize(
@@ -182,6 +193,14 @@ class TestUnittestMockPatch(testutils.CheckerTestCase):
                 from unittest import mock
                 """,
                 "mock.patch.dict",
+                id="partially_qualified",
+            ),
+            pytest.param(
+                """
+                import os
+                from unittest import mock as aliased_mock
+                """,
+                "aliased_mock.patch.dict",
                 id="partially_qualified",
             ),
         ],

--- a/rules_128tech/pylint_plugins/mock_patch_autospec_test.py
+++ b/rules_128tech/pylint_plugins/mock_patch_autospec_test.py
@@ -1,6 +1,7 @@
 """Unit tests for the mock_patch_autospec plugin"""
 
 import contextlib
+from unittest import mock
 
 import astroid
 import astroid.node_classes
@@ -10,7 +11,34 @@ from pylint import testutils
 from rules_128tech.pylint_plugins import mock_patch_autospec
 
 
-class TestUniqueReturnChecker(testutils.CheckerTestCase):
+_MOCK_PATCH_TEST_CASES = [
+    pytest.param('("foo")', True, id="no_autospec",),
+    pytest.param('("foo", FakeFoo())', False, id="new_arg_specified",),
+    pytest.param('("foo", new=FakeFoo())', False, id="new_kwarg_specified",),
+    pytest.param('("foo", spec=FakeFoo)', False, id="spec_kwarg_specified",),
+    pytest.param('("foo", spec_set=FakeFoo)', False, id="spec_set_specified",),
+    pytest.param('("foo", autospec=True)', False, id="autospec_true",),
+    pytest.param('("foo", autospec=False)', False, id="autospec_false",),
+]
+
+
+_MOCK_PATCH_OBJECT_TEST_CASES = [
+    pytest.param('(time, "time")', True, id="no_autospec",),
+    pytest.param('(time, "time", FakeFoo())', False, id="new_arg_specified",),
+    pytest.param('(time, "time", new=FakeFoo())', False, id="new_kwarg_specified",),
+    pytest.param('(time, "time", spec=FakeFoo)', False, id="spec_kwarg_specified",),
+    pytest.param('(time, "time", spec_set=FakeFoo)', False, id="spec_set_specified",),
+    pytest.param('(time, "time", autospec=True)', False, id="autospec_true",),
+    pytest.param('(time, "time", autospec=False)', False, id="autospec_false",),
+]
+
+_MOCK_PATCH_DICT_TEST_CASES = [
+    pytest.param('("os.environ", FOO="bar")', id="kwargs",),
+    pytest.param('("os.environ", {"FOO": "bar"})', id="dict",),
+]
+
+
+class TestUnittestMockPatch(testutils.CheckerTestCase):
 
     CHECKER_CLASS = mock_patch_autospec.MockPatchAutospecChecker
 
@@ -59,16 +87,9 @@ class TestUniqueReturnChecker(testutils.CheckerTestCase):
         ],
     )
     @pytest.mark.parametrize(
-        "call_args, should_flag",
-        [
-            pytest.param('("foo")', True, id="no_autospec",),
-            pytest.param('("foo", FakeFoo())', False, id="new_arg_specified",),
-            pytest.param('("foo", new=FakeFoo())', False, id="new_kwarg_specified",),
-            pytest.param('("foo", autospec=True)', False, id="autospec_true",),
-            pytest.param('("foo", autospec=False)', False, id="autospec_false",),
-        ],
+        "call_args, should_flag", _MOCK_PATCH_TEST_CASES,
     )
-    def test_unittest_mock_patch_context_manager(
+    def test_mock_patch(
         self, source_template, call_args, should_flag, imports, func_name,
     ):
         source_code = source_template.format(
@@ -92,4 +113,169 @@ class TestUniqueReturnChecker(testutils.CheckerTestCase):
             else:
                 stack.enter_context(self.assertNoMessages())
 
+            self.checker.visit_call(patch_call)
+
+    @pytest.mark.parametrize(
+        "imports, func_name",
+        [
+            pytest.param(
+                """
+                import time
+                import unittest.mock
+                """,
+                "unittest.mock.patch.object",
+                id="fully_qualified",
+            ),
+            pytest.param(
+                """
+                import time
+                from unittest import mock
+                """,
+                "mock.patch.object",
+                id="partially_qualified",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "call_args, should_flag", _MOCK_PATCH_OBJECT_TEST_CASES,
+    )
+    def test_mock_patch_object(
+        self, source_template, call_args, should_flag, imports, func_name,
+    ):
+        source_code = source_template.format(
+            imports=imports, func_name=func_name, call_args=call_args
+        )
+        decorator_or_with_stmt: astroid.node_classes.NodeNG = astroid.extract_node(source_code)  # type: ignore
+
+        patch_call = next(decorator_or_with_stmt.get_children())
+
+        with contextlib.ExitStack() as stack:
+            if should_flag:
+                stack.enter_context(
+                    self.assertAddsMessages(
+                        testutils.Message(
+                            msg_id=mock_patch_autospec.MockPatchAutospecChecker.name,
+                            node=patch_call,
+                            args=(func_name,),
+                        ),
+                    )
+                )
+            else:
+                stack.enter_context(self.assertNoMessages())
+
+            self.checker.visit_call(patch_call)
+
+    @pytest.mark.parametrize(
+        "imports, func_name",
+        [
+            pytest.param(
+                """
+                import os
+                import unittest.mock
+                """,
+                "unittest.mock.patch.dict",
+                id="fully_qualified",
+            ),
+            pytest.param(
+                """
+                import os
+                from unittest import mock
+                """,
+                "mock.patch.dict",
+                id="partially_qualified",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "call_args", _MOCK_PATCH_DICT_TEST_CASES,
+    )
+    def test_mock_patch_dict(
+        self, source_template, call_args, imports, func_name,
+    ):
+        source_code = source_template.format(
+            imports=imports, func_name=func_name, call_args=call_args
+        )
+        decorator_or_with_stmt: astroid.node_classes.NodeNG = astroid.extract_node(source_code)  # type: ignore
+
+        patch_call = next(decorator_or_with_stmt.get_children())
+
+        with self.assertNoMessages():
+            self.checker.visit_call(patch_call)
+
+
+class TestPytestMockFixture(testutils.CheckerTestCase):
+
+    CHECKER_CLASS = mock_patch_autospec.MockPatchAutospecChecker
+
+    @pytest.fixture(
+        params=[
+            "mocker",
+            "module_mocker",
+            "class_mocker",
+            "package_mocker",
+            "session_mocker",
+        ]
+    )
+    def fixture_name(self, request):
+        return request.param
+
+    @pytest.fixture
+    def source_template(self, fixture_name):
+        return f"""
+            def test({fixture_name}):
+                {fixture_name}.{{func_name}}{{call_args}}  #@
+        """
+
+    @pytest.mark.parametrize("call_args, should_flag", _MOCK_PATCH_TEST_CASES)
+    def test_mock_patch(self, source_template, should_flag, call_args, fixture_name):
+        func_name = "patch"
+        source_code = source_template.format(call_args=call_args, func_name=func_name)
+        patch_call = astroid.extract_node(source_code)
+
+        with contextlib.ExitStack() as stack:
+            if should_flag:
+                stack.enter_context(
+                    self.assertAddsMessages(
+                        testutils.Message(
+                            msg_id=mock_patch_autospec.MockPatchAutospecChecker.name,
+                            node=patch_call,
+                            args=(f"{fixture_name}.{func_name}",),
+                        ),
+                    )
+                )
+            else:
+                stack.enter_context(self.assertNoMessages())
+
+            self.checker.visit_call(patch_call)
+
+    @pytest.mark.parametrize("call_args, should_flag", _MOCK_PATCH_OBJECT_TEST_CASES)
+    def test_mock_object(self, source_template, call_args, should_flag, fixture_name):
+        func_name = "patch.object"
+        source_code = source_template.format(call_args=call_args, func_name=func_name)
+        patch_call = astroid.extract_node(source_code)
+
+        with contextlib.ExitStack() as stack:
+            if should_flag:
+                stack.enter_context(
+                    self.assertAddsMessages(
+                        testutils.Message(
+                            msg_id=mock_patch_autospec.MockPatchAutospecChecker.name,
+                            node=patch_call,
+                            args=(f"{fixture_name}.{func_name}",),
+                        ),
+                    )
+                )
+            else:
+                stack.enter_context(self.assertNoMessages())
+
+            self.checker.visit_call(patch_call)
+
+    @pytest.mark.parametrize("call_args", _MOCK_PATCH_DICT_TEST_CASES)
+    def test_mock_dict(self, source_template, call_args):
+        source_code = source_template.format(
+            call_args=call_args, func_name="patch.dict"
+        )
+        patch_call = astroid.extract_node(source_code)
+
+        with self.assertNoMessages():
             self.checker.visit_call(patch_call)

--- a/rules_128tech/pylint_plugins/mock_patch_autospec_test.py
+++ b/rules_128tech/pylint_plugins/mock_patch_autospec_test.py
@@ -1,0 +1,95 @@
+"""Unit tests for the mock_patch_autospec plugin"""
+
+import contextlib
+
+import astroid
+import astroid.node_classes
+import pytest
+from pylint import testutils
+
+from rules_128tech.pylint_plugins import mock_patch_autospec
+
+
+class TestUniqueReturnChecker(testutils.CheckerTestCase):
+
+    CHECKER_CLASS = mock_patch_autospec.MockPatchAutospecChecker
+
+    @pytest.fixture(
+        params=[
+            pytest.param(
+                """
+                {imports}
+
+                class FakeFoo:
+                    pass
+
+                @{func_name}{call_args}  #@
+                def test():
+                    pass
+                """,
+                id="decorator",
+            ),
+            pytest.param(
+                """
+                {imports}
+
+                class FakeFoo:
+                    pass
+
+                def test():
+                    with {func_name}{call_args}:  #@
+                        pass
+                """,
+                id="context_manager",
+            ),
+        ]
+    )
+    def source_template(self, request):
+        return request.param
+
+    @pytest.mark.parametrize(
+        "imports, func_name",
+        [
+            pytest.param(
+                "import unittest.mock", "unittest.mock.patch", id="fully_qualified"
+            ),
+            pytest.param(
+                "from unittest import mock", "mock.patch", id="partially_qualified"
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "call_args, should_flag",
+        [
+            pytest.param('("foo")', True, id="no_autospec",),
+            pytest.param('("foo", FakeFoo())', False, id="new_arg_specified",),
+            pytest.param('("foo", new=FakeFoo())', False, id="new_kwarg_specified",),
+            pytest.param('("foo", autospec=True)', False, id="autospec_true",),
+            pytest.param('("foo", autospec=False)', False, id="autospec_false",),
+        ],
+    )
+    def test_unittest_mock_patch_context_manager(
+        self, source_template, call_args, should_flag, imports, func_name,
+    ):
+        source_code = source_template.format(
+            imports=imports, func_name=func_name, call_args=call_args
+        )
+        decorator_or_with_stmt: astroid.node_classes.NodeNG = astroid.extract_node(source_code)  # type: ignore
+
+        patch_call = next(decorator_or_with_stmt.get_children())
+
+        with contextlib.ExitStack() as stack:
+            if should_flag:
+                stack.enter_context(
+                    self.assertAddsMessages(
+                        testutils.Message(
+                            msg_id=mock_patch_autospec.MockPatchAutospecChecker.name,
+                            node=patch_call,
+                            args=(func_name,),
+                        ),
+                    )
+                )
+            else:
+                stack.enter_context(self.assertNoMessages())
+
+            self.checker.visit_call(patch_call)

--- a/thirdparty/pip/3/requirements.in
+++ b/thirdparty/pip/3/requirements.in
@@ -1,3 +1,4 @@
+astroid
 click
 coverage
 pdbpp


### PR DESCRIPTION
We have a major problem of forgetting to put `autospec=True` into our calls to `mock.patch` and `mocker.patch` in unit tests. This can easily lead to incorrect test behavior, since all method calls/attribute access will magically "work" even if the method/attribute does not exist in the real object.

This pylint plugin will be implicitly loaded in all pylint tests, and will enforce that calls to `mock.patch` must use `autospec=True`. The plugin can be disabled on a given line like any other pylint directive, i.e. a special comment`# pylint:disable=mock-patch-autospec`.

Questions about behavior: 
* Should we simply require `autospec=<anything>`, or require `autospec=True`? I'm not gonna bother trying to parse expressions on the RHS of the arg, but that is probably never going to happen anyway
* Any other object names besides `mock` and `mocker` needed? It's a little hacky to use the actual _name_ of the thing for this check but it only causes problems in unusual cases like these, which should be rare:
```py
import mock as my_mock
import pytest

@pytest.fixture
def some_mock(mocker):
    foo = mocker.Mock()
    return mocker

def test_foo(some_mock):
    ...
```
