### PR TITLE
Fix typo (status_code versus return_code)

### DIFF
--- a/thirdparty/pip/prettier-errors.patch
+++ b/thirdparty/pip/prettier-errors.patch
@@ -1,5 +1,5 @@
 diff --git a/src/whl.py b/src/whl.py
-index 7c5942e..865a2db 100644
+index 7c5942e..c130fdd 100644
 --- a/src/whl.py
 +++ b/src/whl.py
 @@ -6,6 +6,7 @@ import os
@@ -17,7 +17,7 @@ index 7c5942e..865a2db 100644
 -    cmd.main(pip_args)
 +    status_code = cmd.main(pip_args)
 +    if status_code != SUCCESS:
-+        raise _Error(return_code)
++        raise _Error(status_code)
  
      # need dist-info directory for pkg_resources to be able to find the packages
      dist_info = glob.glob(os.path.join(directory, "*.dist-info"))[0]


### PR DESCRIPTION
The point of this patch was to have prettier errors... this typo makes things worse!
```
ERROR: An error occurred during the fetch of repository 'pypi__36__pydash_4_7_6':
   Traceback (most recent call last):
        File "external/com_github_ali5h_rules_pip/defs.bzl", line 218, column 13, in _whl_impl
                fail("whl_library failed: %s (%s)" % (result.stdout, result.stderr))
Error in fail: whl_library failed: Looking in indexes: <omitted>
 (WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x10cb3fe48>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',)': /api/pypi/pydash/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x10cb3fa90>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',)': /api/pypi/pydash/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x10cb3f048>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',)': /api/pypi/pydash/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x10cb7cc50>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',)': /api/pypi/pydash/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x10cb7ce10>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',)': /api/pypi/pydash/
ERROR: Could not find a version that satisfies the requirement pydash==4.7.6 (from -c external/pip3_current/requirements.txt (line 629)) (from versions: none)
ERROR: No matching distribution found for pydash==4.7.6 (from -c external/pip3_current/requirements.txt (line 629))
Traceback (most recent call last):
  File "external/com_github_ali5h_rules_pip/src/whl.py", line 298, in <module>
    main()
  File "external/com_github_ali5h_rules_pip/src/whl.py", line 235, in main
    pkg = install_package(args.package, args.directory, pip_args)
  File "external/com_github_ali5h_rules_pip/src/whl.py", line 78, in install_package
    raise _Error(return_code)
NameError: name 'return_code' is not defined
)
```