### PR TITLE
support bazel version 5.0.0

### DIFF
--- a/python/lint/rules.bzl
+++ b/python/lint/rules.bzl
@@ -10,7 +10,7 @@ _AUTO_ADD_RULE_TYPES = [
     "py_test",
 ]
 
-def add_python_lint_tests(pylint = True, rcfile = None, deps = [], **kwargs):
+def add_python_lint_tests(pylint = True, rcfile = None, **kwargs):
     """
     Add all the available static analysis available for each python target in the current BUILD file.
 
@@ -27,7 +27,6 @@ def add_python_lint_tests(pylint = True, rcfile = None, deps = [], **kwargs):
     Args:
         pylint(bool): control whether pylint tests are created.
         rcfile(label): pylint configuration file
-        deps(label_list): extra dependencies of the pylint test
         **kwargs: Pass other keyword arguments directly to pylint_test.
 
     """
@@ -50,7 +49,7 @@ def add_python_lint_tests(pylint = True, rcfile = None, deps = [], **kwargs):
         pylint_test(
             name = "pylint",
             srcs = depset(pylint_srcs).to_list(),
-            deps = depset(direct = deps, transitive = [depset(pylint_deps)]),
+            deps = pylint_deps,
             rcfile = rcfile,
             **kwargs
         )


### PR DESCRIPTION
I don't know why add_python_lint_tests even had a `deps` argument...