### PR TITLE
teach `pytest_test` how to not shuffle a test via the commandline

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,3 +4,6 @@ build:docs --build_tag_filters="docs"
 
 # don't build documentation by default
 build --build_tag_filters="-docs"
+
+# Disable shuffling the execution order of test cases within a single test.
+build:noshuffle --define shuffle=off

--- a/private/BUILD.bazel
+++ b/private/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
 
 config_setting(
     name = "optimize",
@@ -11,6 +11,13 @@ config_setting(
     name = "disable_color",
     define_values = {
         "color": "no",
+    },
+)
+
+config_setting(
+    name = "disable_shuffle",
+    define_values = {
+        "shuffle": "off",
     },
 )
 

--- a/private/cfg.bzl
+++ b/private/cfg.bzl
@@ -3,4 +3,5 @@ Configuration options that control the build
 """
 
 DISABLE_COLOR = str(Label("//private:disable_color"))
+DISABLE_SHUFFLE = str(Label("//private:disable_shuffle"))
 OPTIMIZE = str(Label("//private:optimize"))


### PR DESCRIPTION
If an explicit value of `True` or `False` is not passed to `pytest_test` for the `shuffle` argument then the value can be configured on the command line. The default is still to shuffle tests.

```bzl
# Will never be shuffled.
pytest_test(
    name = "one",
    shuffle = False,
)

# Will always be shuffled.
pytest_test(
    name = "two",
    shuffle = True,
)

# Will shuffle by default, can be disabled by `--config=noshuffle`.
pytest_test(
    name = "three",
)
```