### PR TITLE
Always ensure sharding happens before test shuffle

### DIFF
--- a/rules_128tech/pytest_plugins/pytest_bazel_sharder.py
+++ b/rules_128tech/pytest_plugins/pytest_bazel_sharder.py
@@ -1,7 +1,14 @@
 """pytest plugin which filters the collected test targets based on the current shard."""
 
+import pytest
+
 from rules_128tech import sharder
 
 
-def pytest_collection_modifyitems(config, items):
+# pytest-randomly uses tryfirst=True, so this is a hookwrapper to ensure that sharding
+# happens before test shuffling. Otherwise, each shard would select its test cases
+# from a different permutation, possibly resulting in duplicates or missing tests.
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_collection_modifyitems(items):
     items[:] = sharder.filter_items(items)
+    yield


### PR DESCRIPTION
If shuffling happens first (default for pytest-randomly since its hook has `tryfirst=True`), different shards will start off with a base set of items that are different from each other. As a result, the bucketizing will be inconsistent across shards and some tests may be run multiple times or not run at all!

Ensuring our plugin wraps the randomly plugin means we always shard consistently first, then the tests within a shard will be shuffled randomly instead.