### PR TITLE
Use pip-compile builtin header to avoid duplicates

### DIFF
--- a/python/compile/compile.bzl
+++ b/python/compile/compile.bzl
@@ -39,7 +39,8 @@ def _compile_pip_requirements_impl(ctx):
         "@@REQUIREMENTS_TXT_PATH@@": requirements_txt_path,
         "@@PYTHON_INTERPRETER_PATH@@": python_interpreter,
         "@@PIP_COMPILE_BINARY@@": pip_compile.short_path,
-        "@@HEADER@@": ctx.attr.header,
+        "@@CUSTOM_COMPILE_COMMAND@@": ctx.attr.custom_compile_command or "bazel run %s" % ctx.label,
+        "@@QUIET_ARG@@": "--quiet" if not ctx.attr.verbose else "--verbose",
     }
 
     ctx.actions.expand_template(
@@ -72,17 +73,18 @@ compile_pip_requirements = rule(
         "data": attr.label_list(allow_files = True),
         "requirements_txt": attr.string(default = "requirements.txt"),
         "python_version": attr.string(default = "PY3", values = ("PY2", "PY3")),
-        "header": attr.string(default = "# This file is generated code. DO NOT EDIT."),
+        "custom_compile_command": attr.string(),
+        "verbose": attr.bool(default = False),
         "_pip2_compile": attr.label(
             default = Label("//python/compile:compile2.zip"),
             allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "_pip3_compile": attr.label(
             default = Label("//python/compile:compile.zip"),
             allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "_template": attr.label(

--- a/python/compile/compile_pip_requirements_wrapper_template.sh
+++ b/python/compile/compile_pip_requirements_wrapper_template.sh
@@ -10,15 +10,13 @@ PYTHON_INTERPRETER_PATH="@@PYTHON_INTERPRETER_PATH@@"
 PIP_COMPILE_BINARY="@@PIP_COMPILE_BINARY@@"
 
 echo "Compiling $REQUIREMENTS_TXT_PATH"
+
+export CUSTOM_COMPILE_COMMAND="@@CUSTOM_COMPILE_COMMAND@@"
 $PYTHON_INTERPRETER_PATH $PIP_COMPILE_BINARY \
     --output-file $REQUIREMENTS_TXT_PATH \
-    --no-header \
-    --no-index \
+    "@@QUIET_ARG@@" \
+    --no-emit-index-url \
     --generate-hashes \
     --allow-unsafe \
     "$@" \
     $REQUIREMENTS_IN_PATH
-set -x
-echo "@@HEADER@@" > requirements.tmp
-cat $REQUIREMENTS_TXT_PATH >> requirements.tmp
-cp requirements.tmp $REQUIREMENTS_TXT_PATH

--- a/python/compile/compile_pip_requirements_wrapper_template.sh
+++ b/python/compile/compile_pip_requirements_wrapper_template.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 if [ -z ${BUILD_WORKSPACE_DIRECTORY+x} ]; then
     echo "This script must be executed with Bazel"
     exit 1
@@ -13,10 +16,13 @@ echo "Compiling $REQUIREMENTS_TXT_PATH"
 
 export CUSTOM_COMPILE_COMMAND="@@CUSTOM_COMPILE_COMMAND@@"
 $PYTHON_INTERPRETER_PATH $PIP_COMPILE_BINARY \
-    --output-file $REQUIREMENTS_TXT_PATH \
+    --output-file "$REQUIREMENTS_TXT_PATH" \
     "@@QUIET_ARG@@" \
+    --header \
     --no-emit-index-url \
     --generate-hashes \
     --allow-unsafe \
     "$@" \
     $REQUIREMENTS_IN_PATH
+
+echo "Compiled $REQUIREMENTS_TXT_PATH successfully!"


### PR DESCRIPTION
Also turn down the verbosity by default, no need to spam with the full contents of the file every time we generate it.

Before, running multiple updates in a row could end up with a duplicated header, since we didn't do anything special and `pip-compile` seems to preserve comments by default:

```requirements.txt
# This file is generated code. DO NOT EDIT.
# This file is generated code. DO NOT EDIT.
aiohttp-cors==0.7.0 \
    --hash=sha256:0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e \
    --hash=sha256:4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d \
    # via -r thirdparty/bazelbuild/pip/3/requirements.in
aiohttp-swagger==1.0.5 \
    --hash=sha256:b9db24513c2092e4d5aecc897d7df01e7ba8ed2c23699536c20d1743e15f87e4 \
    # via -r thirdparty/bazelbuild/pip/3/requirements.in
```

After, running multiple updates in a row just rewrites the same header:
```requirements.txt
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    bazel run //thirdparty/bazelbuild/pip/3:compile
#
aiohttp-cors==0.7.0 \
    --hash=sha256:0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e \
    --hash=sha256:4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d \
    # via -r thirdparty/bazelbuild/pip/3/requirements.in
aiohttp-swagger==1.0.5 \
    --hash=sha256:b9db24513c2092e4d5aecc897d7df01e7ba8ed2c23699536c20d1743e15f87e4 \
    # via -r thirdparty/bazelbuild/pip/3/requirements.in
```

----

Also make a verbosity arg to the `compile` command that we can plumb into our `--config=verbose`, and default to `--quiet` (no need to dump the whole generated file to the user).